### PR TITLE
feat: 타자 입력 커서 표시 및 진행도 UI 구현

### DIFF
--- a/components/atoms/TypingInput.tsx
+++ b/components/atoms/TypingInput.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { forwardRef } from "react";
+
+type TypingInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+export const TypingInput = forwardRef<HTMLInputElement, TypingInputProps>(
+  ({ value, onChange }, ref) => {
+    return (
+      <input
+        ref={ref}
+        autoFocus
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        // 화면에는 안 보이지만, 포커스는 받을 수 있게
+        className="absolute left-0 top-0 w-px h-px opacity-0 pointer-events-none"
+      />
+    );
+  }
+);
+
+TypingInput.displayName = "TypingInput";

--- a/components/molecules/TypingDisplay.tsx
+++ b/components/molecules/TypingDisplay.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+type TypingDisplayProps = {
+    text: string;   // 윈본 가사
+    input: string; // 사용자가 타이핑한 글자
+    cursorIndex: number;
+}
+
+export function TypingDisplay({text, input, cursorIndex}: TypingDisplayProps){
+    const safeText = text ?? "";
+    const chars = safeText.split("");
+
+    return(
+        <div className="flex flex-wrap gap-[2px] text-lg leading-7">
+            {safeText.split("").map((char, index) => {
+                const typed = input[index];
+
+                let color = "text-neutral-400"
+                if(typed != null){
+                    color = typed === char ? "text-neutral-900" : "text-red-500"
+                }
+                const isCursorHere = index === cursorIndex;
+
+                return(
+                    <span key={index} >
+                        {isCursorHere && (
+                            <span className="inline-block w-[2px] h-[1.3em] bg-blue-500 align-middle animate-pulse mr-[1px]"></span>
+                        )}
+                        <span className={color}>{char}</span>
+                    </span>
+                )
+            })}
+            {/* 커서가 "맨 끝"에 있을 때(마지막 글자 뒤) */}
+            {cursorIndex === chars.length && (
+                <span className="inline-block w-[2px] h-[1.3em] bg-blue-500 align-middle animate-pulse ml-[1px]" />
+            )}
+        </div>
+    )
+}

--- a/components/organisms/SongTypeBoard.tsx
+++ b/components/organisms/SongTypeBoard.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import type { Song } from "@/app/page";
+import { TypingDisplay } from "../molecules/TypingDisplay";
+import { useState, useRef } from "react";
+import { TypingInput } from "../atoms/TypingInput";
 
 type Props = {
     song: {
@@ -12,6 +15,17 @@ type Props = {
 }
 
 export function SongTypeBoard({song}: Props){
+    const [input, setInput] = useState("");
+    const text = song?.lyrice ?? "가사가 없습니다(디버깅용)"
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const focusInput = () => {
+        inputRef.current?.focus();
+    }
+    const progress = Math.min(
+        Math.round((input.length / text.length) * 100),
+        100
+    );
+    const cursorIndex = Math.min(input.length, text.length);
     return (
         <div className="w-full max-w-4xl rounded-xl border border-neutral-300 bg-white shadow-lg">
             {/* 상단 정보 영역 */}
@@ -24,12 +38,27 @@ export function SongTypeBoard({song}: Props){
                     Typing Something · Code typing practice
                 </div>
             </div>
-            {/* 가사 타자 영역 */}
-            <div className="px-6 py-6 leading-7 text-neutral-800">{song.lyrice}</div>
+                {/* 가사 타자 영역 */}
+            <div className="px-6 py-6 space-y-4" onClick={focusInput}>
+                {/* 가사 표시 */}
+                <TypingDisplay text={text} input={input} cursorIndex={cursorIndex}/>
+                
+                {/* 진행도 바 */}
+                <div className="h-2 w-full bg-neutral-200 rounded-full overflow-hidden">
+                    <div 
+                        className="h-full bg-blue-500 transition-all"
+                        style={{width: `${progress}%`}}
+                    />
+                </div>
+                {/* 인풋 영역 */}
+                <TypingInput ref={inputRef} value={input} onChange={setInput}/>
+            </div>
+            
             {/* 하단 바 - 나중에 WPM/ACC 등 들어갈 자리 */}
             <div className="flex items-center justify-between border-t border-neutral-200 px-4 py-3 text-xs text-neutral-500">
                 <span>Song ID: {song.songId}</span>
                 <span>Press Enter to start typing</span>
+                <span>{progress}% complete</span>
             </div>
         </div>
     )


### PR DESCRIPTION
## 개요
- 노래 가사 타자 기능의 핵심 UX를 위한 커서 및 진행도 UI를 구현했습니다.

## 주요 기능
- 타자 시작 시 맨 앞에 커서 표시
- 입력에 따라 커서 위치가 실시간으로 이동
- 전체 가사 대비 입력 진행도(%) 계산 및 Progress Bar UI 추가
- 숨겨진 input + 커스텀 Display 구조 적용

## 구조
- organisms/SongTypeBoard
- molecules/TypingDisplay
- atoms/TypingInput

## 추후 작업
- 정확도(ACC), WPM, CPM 계산 기능 추가 예정