### PR TITLE
feat: 타이핑 화면 하단 컨트롤 UI 구성 및 Atomic 컴포넌트 분리

### DIFF
--- a/components/atoms/IconButton.tsx
+++ b/components/atoms/IconButton.tsx
@@ -1,0 +1,21 @@
+"use client"
+import { ReactNode } from "react"
+type Props = {
+    children: ReactNode;
+    ariaLabel: string;
+    onClick?: () => void;
+    variant?: "default" | "ghost";
+}
+export function IconButton({children, ariaLabel, onClick, variant = "default"}: Props){
+    const variantStyle = variant === "default" ? "rounded-full border border-neutral-200 " : ""
+    return (
+        <button 
+            type="button"
+            aria-label="ariaLabel"
+            onClick={onClick}
+            className={`h-7 w-7 grid place-items-center text-neutral-800 hover:bg-neutral-50 ${variantStyle}`} 
+            >
+            {children}
+        </button>
+    )
+}

--- a/components/atoms/ProgressBar.tsx
+++ b/components/atoms/ProgressBar.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+type Props = {
+  value: number; // 0~100
+};
+
+export function ProgressBar({ value }: Props) {
+  return (
+    <div className="h-0.5 w-full overflow-hidden rounded-full bg-neutral-200">
+      <div className="h-full bg-neutral-900 transition-all" style={{ width: `${value}%` }} />
+    </div>
+  );
+}

--- a/components/atoms/StatItem.tsx
+++ b/components/atoms/StatItem.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+type Props = {
+  label: string;
+  value: number | string;
+};
+
+export function StatItem({ label, value }: Props) {
+  return (
+    <div className="flex flex-col items-end">
+      <span className="text-[10px] text-neutral-400">{label}</span>
+      <span className="font-semibold text-neutral-900">{value}</span>
+    </div>
+  );
+}

--- a/components/molecules/TypingBottomBar.tsx
+++ b/components/molecules/TypingBottomBar.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { IconButton } from "../atoms/IconButton";
+
+export function TypingBottomBar() {
+  return (
+    <div className="flex items-center justify-between border-t border-neutral-200 px-4 py-3">
+      {/* 좌: 리셋 + prev/next */}
+      <div className="flex items-center gap-3">
+        <IconButton ariaLabel="처음으로">
+          {/* refresh */}
+          <svg viewBox="0 0 24 24" className="size-5" fill="currentColor">
+            <path d="M19.146 4.854l-1.489 1.489A8 8 0 1 0 12 20a8.094 8.094 0 0 0 7.371-4.886 1 1 0 1 0-1.842-.779A6.071 6.071 0 0 1 12 18a6 6 0 1 1 4.243-10.243l-1.39 1.39a.5.5 0 0 0 .354.854H19.5A.5.5 0 0 0 20 9.5V5.207a.5.5 0 0 0-.854-.353z" />
+          </svg>
+        </IconButton>
+
+        <div className="flex items-center gap-2">
+          <IconButton ariaLabel="이전">
+            <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
+              <path
+                fillRule="evenodd"
+                d="M11.78 5.22a.75.75 0 0 1 0 1.06L8.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </IconButton>
+
+          <IconButton ariaLabel="다음">
+            <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
+              <path
+                fillRule="evenodd"
+                d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </IconButton>
+        </div>
+      </div>
+
+      {/* 우: bookmark/like */}
+      <div className="flex items-center gap-2">
+        <IconButton ariaLabel="찜" variant="ghost">
+          <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
+            <path
+              fillRule="evenodd"
+              d="M10 2c-1.716 0-3.408.106-5.07.31C3.806 2.45 3 3.414 3 4.517V17.25a.75.75 0 0 0 1.075.676L10 15.082l5.925 2.844A.75.75 0 0 0 17 17.25V4.517c0-1.103-.806-2.068-1.93-2.207A41.403 41.403 0 0 0 10 2Z"
+              clipRule="evenodd"
+            />
+          </svg>
+        </IconButton>
+
+        <IconButton ariaLabel="좋아요" variant="ghost">
+          <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
+            <path d="m9.653 16.915-.005-.003-.019-.01a20.759 20.759 0 0 1-1.162-.682 22.045 22.045 0 0 1-2.582-1.9C4.045 12.733 2 10.352 2 7.5a4.5 4.5 0 0 1 8-2.828A4.5 4.5 0 0 1 18 7.5c0 2.852-2.044 5.233-3.885 6.82a22.049 22.049 0 0 1-3.744 2.582l-.019.01-.005.003h-.002a.739.739 0 0 1-.69.001l-.002-.001Z" />
+          </svg>
+        </IconButton>
+      </div>
+    </div>
+  );
+}

--- a/components/molecules/TypingStage.tsx
+++ b/components/molecules/TypingStage.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { RefObject } from "react";
+import { TypingDisplay } from "./TypingDisplay";
+import { TypingInput } from "../atoms/TypingInput";
+
+type Props = {
+  text: string;
+  input: string;
+  cursorIndex: number;
+  onFocusRequest: () => void;
+  inputRef: RefObject<HTMLInputElement | null>;
+  onChangeInput: (v: string) => void;
+};
+
+export function TypingStage({
+  text,
+  input,
+  cursorIndex,
+  onFocusRequest,
+  inputRef,
+  onChangeInput,
+}: Props) {
+  return (
+    <div className="relative px-6 py-8 space-y-4 cursor-text" onClick={onFocusRequest}>
+      <TypingDisplay text={text} input={input} cursorIndex={cursorIndex} />
+      <TypingInput ref={inputRef} value={input} onChange={onChangeInput} />
+    </div>
+  );
+}

--- a/components/molecules/TypingTopBar.tsx
+++ b/components/molecules/TypingTopBar.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { ProgressBar } from "../atoms/ProgressBar";
+import { StatItem } from "../atoms/StatItem";
+
+type Props = {
+  title: string;
+  artist: string;
+  wpm: number;
+  cpm: number;
+  acc: number;
+  progress: number;
+};
+
+export function TypingTopBar({ title, artist, wpm, cpm, acc, progress }: Props) {
+  return (
+    <div className="px-4 py-3">
+      <div className="flex items-start justify-between gap-4">
+        {/* 좌: 메타 */}
+        <div className="flex items-center gap-3">
+          <div className="h-10 w-10 rounded-md bg-neutral-200" />
+          <div className="leading-tight">
+            <div className="text-xs font-semibold text-neutral-900">{title}</div>
+            <div className="text-[11px] text-neutral-500">{artist}</div>
+          </div>
+        </div>
+
+        {/* 우: stats */}
+        <div className="flex items-center gap-3 text-xs text-neutral-600">
+          <StatItem label="WPM" value={wpm} />
+          <div className="h-7 w-px bg-neutral-200" />
+          <StatItem label="CPM" value={cpm} />
+          <div className="h-7 w-px bg-neutral-200" />
+          <StatItem label="ACC" value={`${acc}%`} />
+        </div>
+      </div>
+
+      <div className="mt-3">
+        <ProgressBar value={progress} />
+      </div>
+    </div>
+  );
+}

--- a/components/organisms/SongTypeBoard.tsx
+++ b/components/organisms/SongTypeBoard.tsx
@@ -4,62 +4,62 @@ import type { Song } from "@/app/page";
 import { TypingDisplay } from "../molecules/TypingDisplay";
 import { useState, useRef } from "react";
 import { TypingInput } from "../atoms/TypingInput";
+import { TypingBottomBar } from "../molecules/TypingBottomBar";
+import { TypingStage } from "../molecules/TypingStage";
+import { TypingTopBar } from "../molecules/TypingTopBar";
 
 type Props = {
-    song: {
-        songId: number;
-        title: string;
-        artist: string;
-        lyrice: string;
-    }
-}
+  song: {
+    songId: number;
+    title: string;
+    artist: string;
+    lyrice: string;
+  };
+};
 
-export function SongTypeBoard({song}: Props){
-    const [input, setInput] = useState("");
-    const text = song?.lyrice ?? "가사가 없습니다(디버깅용)"
-    const inputRef = useRef<HTMLInputElement | null>(null);
-    const focusInput = () => {
-        inputRef.current?.focus();
-    }
-    const progress = Math.min(
-        Math.round((input.length / text.length) * 100),
-        100
-    );
-    const cursorIndex = Math.min(input.length, text.length);
-    return (
-        <div className="w-full max-w-4xl rounded-xl border border-neutral-300 bg-white shadow-lg">
-            {/* 상단 정보 영역 */}
-            <div className="flex items-center justify-between border-b border-neutral-200 px-4 py-3 text-sm">
-                <div>
-                    <div className="font-semibold">{song.title}</div>
-                    <div className="text-xs text-neutral-500">by {song.artist}</div>
-                </div>
-                <div className="text-[11px] text-neutral-400">
-                    Typing Something · Code typing practice
-                </div>
-            </div>
-                {/* 가사 타자 영역 */}
-            <div className="px-6 py-6 space-y-4" onClick={focusInput}>
-                {/* 가사 표시 */}
-                <TypingDisplay text={text} input={input} cursorIndex={cursorIndex}/>
-                
-                {/* 진행도 바 */}
-                <div className="h-2 w-full bg-neutral-200 rounded-full overflow-hidden">
-                    <div 
-                        className="h-full bg-blue-500 transition-all"
-                        style={{width: `${progress}%`}}
-                    />
-                </div>
-                {/* 인풋 영역 */}
-                <TypingInput ref={inputRef} value={input} onChange={setInput}/>
-            </div>
-            
-            {/* 하단 바 - 나중에 WPM/ACC 등 들어갈 자리 */}
-            <div className="flex items-center justify-between border-t border-neutral-200 px-4 py-3 text-xs text-neutral-500">
-                <span>Song ID: {song.songId}</span>
-                <span>Press Enter to start typing</span>
-                <span>{progress}% complete</span>
-            </div>
-        </div>
-    )
+export function SongTypeBoard({ song }: Props) {
+  const [input, setInput] = useState("");
+  const text = song?.lyrice ?? "가사가 없습니다(디버깅용)";
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const focusInput = () => inputRef.current?.focus();
+
+  const progress = Math.min(Math.round((input.length / text.length) * 100), 100);
+  const cursorIndex = Math.min(input.length, text.length);
+
+  // ✅ UI만 먼저: 더미 값
+  const wpm = 72;
+  const cpm = 360;
+  const acc = 98;
+
+  return (
+    <div className="w-full max-w-4xl rounded-xl border border-neutral-300 bg-white shadow-lg">
+      {/* =======================
+          상단: 타이틀 + Stats + Progress
+         ======================= */}
+      <TypingTopBar 
+        title={song.title}
+        artist={song.artist}
+        wpm={wpm}
+        cpm={cpm}
+        acc={acc}
+        progress={progress}
+      />
+      {/* =======================
+          중앙: 타이핑 영역
+         ======================= */}
+        <TypingStage
+          text={text}
+          input={input}
+          cursorIndex={cursorIndex}
+          onFocusRequest={focusInput}
+          inputRef={inputRef}
+          onChangeInput={setInput}
+        />     
+         {/* =======================
+          하단: 메타정보(이미지) + 버튼들
+         ======================= */}
+        <TypingBottomBar />
+    </div>
+  );
 }

--- a/hooks/useTypingEngine.ts
+++ b/hooks/useTypingEngine.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+
+type UseTypingEngineOptions = {
+  /** input을 원문 길이까지만 받도록 제한 (기본 false) */
+  clampToTextLength?: boolean;
+};
+
+export type TypingEngine = {
+  // data
+  text: string;
+  input: string;
+  cursorIndex: number;
+  progress: number; // 0~100
+
+  // refs
+  inputRef: React.RefObject<HTMLInputElement | null>;
+
+  // actions
+  setInput: (value: string) => void;
+  focus: () => void;
+  reset: () => void;
+
+  // helpers (나중에 stats 붙일 때 유용)
+  typedLength: number;
+};
+
+export function useTypingEngine(text: string, options: UseTypingEngineOptions = {}): TypingEngine {
+  const { clampToTextLength = false } = options;
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [input, _setInput] = useState("");
+
+  const safeText = text ?? "";
+
+  const setInput = useCallback(
+    (value: string) => {
+      if (!clampToTextLength) {
+        _setInput(value);
+        return;
+      }
+      // 원문 길이 이상 입력을 막고 싶을 때(옵션)
+      _setInput(value.slice(0, safeText.length));
+    },
+    [clampToTextLength, safeText.length]
+  );
+
+  const focus = useCallback(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const reset = useCallback(() => {
+    _setInput("");
+    // UX: reset하면 다시 타이핑 바로 가능하게 포커스 유지
+    inputRef.current?.focus();
+  }, []);
+
+  const typedLength = input.length;
+
+  const cursorIndex = useMemo(() => {
+    // 커서 = 현재 입력 길이 (원문보다 길어질 때는 끝에 고정)
+    return Math.min(typedLength, safeText.length);
+  }, [typedLength, safeText.length]);
+
+  const progress = useMemo(() => {
+    if (safeText.length === 0) return 0;
+    const pct = Math.round((typedLength / safeText.length) * 100);
+    return Math.min(pct, 100);
+  }, [typedLength, safeText.length]);
+
+  return {
+    text: safeText,
+    input,
+    cursorIndex,
+    progress,
+    inputRef,
+    setInput,
+    focus,
+    reset,
+    typedLength,
+  };
+}


### PR DESCRIPTION
## 개요
타이핑 화면의 하단 컨트롤 영역 UI를 구성하고,
Atomic Design 기준에 맞춰 재사용 가능한 버튼 컴포넌트를 분리

## 주요 변경 사항
- 타이핑 화면 하단 컨트롤 영역 UI 구성
  - 되돌아가기 / 이전 / 다음 버튼
  - 찜 / 좋아요 버튼
- IconButton 컴포넌트에 variant(default/ghost) 추가
  - 컨트롤 버튼: border 있는 default 스타일
  - 리액션 버튼: border 없는 ghost 스타일

## 비고
- 현재는 UI만 구현되어 있음. 동작 로직은 추후 추가 예정