### PR TITLE
ui: 타이핑 화면 레이아웃 재배치 및 가사 UI 스타일 조정

### DIFF
--- a/components/atoms/Logo.tsx
+++ b/components/atoms/Logo.tsx
@@ -2,11 +2,14 @@
 export function Logo() {
     return (
       <div className="flex items-center gap-2">
-        <div className="h-6 w-6 rounded-md bg-gradient-to-tr from-teal-400 to-emerald-300" />
+      <div className="h-6 w-6 rounded-md bg-gradient-to-tr from-[#fb4058] to-[#fb576e]" />  
         <div
           className="text-lg font-semibold tracking-wide"
         >
-          LyricType<span className="ml-0.5 font-bold text-lg text-teal-400 typing-cursor">|</span>
+        LyricType
+        <span className="ml-0.5 font-bold text-lg text-[#fb4058] typing-cursor">
+          |
+        </span>
         </div>
       </div>
     );

--- a/components/molecules/TypingBottomBar.tsx
+++ b/components/molecules/TypingBottomBar.tsx
@@ -1,59 +1,50 @@
 "use client";
 
+import { ProgressBar } from "../atoms/ProgressBar";
 import { IconButton } from "../atoms/IconButton";
+type Props = {
+  title: string;
+  artist: string;
+  wpm: number;
+  cpm: number;
+  acc: number;
+  progress: number;
+};
 
-export function TypingBottomBar() {
+export function TypingBottomBar({ title, artist, progress }: Props) {
   return (
-    <div className="flex items-center justify-between border-t border-neutral-200 px-4 py-3">
-      {/* 좌: 리셋 + prev/next */}
-      <div className="flex items-center gap-3">
-        <IconButton ariaLabel="처음으로">
-          {/* refresh */}
-          <svg viewBox="0 0 24 24" className="size-5" fill="currentColor">
-            <path d="M19.146 4.854l-1.489 1.489A8 8 0 1 0 12 20a8.094 8.094 0 0 0 7.371-4.886 1 1 0 1 0-1.842-.779A6.071 6.071 0 0 1 12 18a6 6 0 1 1 4.243-10.243l-1.39 1.39a.5.5 0 0 0 .354.854H19.5A.5.5 0 0 0 20 9.5V5.207a.5.5 0 0 0-.854-.353z" />
-          </svg>
-        </IconButton>
-
-        <div className="flex items-center gap-2">
-          <IconButton ariaLabel="이전">
-            <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
-              <path
-                fillRule="evenodd"
-                d="M11.78 5.22a.75.75 0 0 1 0 1.06L8.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </IconButton>
-
-          <IconButton ariaLabel="다음">
-            <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
-              <path
-                fillRule="evenodd"
-                d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </IconButton>
-        </div>
+    <div className="px-4 py-3">
+       <div className="mb-3">
+        <ProgressBar value={progress} />
       </div>
+      <div className="flex items-start justify-between gap-4">
+        {/* 좌: 메타 */}
+        <div className="flex items-center gap-3">
+          <div className="h-10 w-10 rounded-md bg-neutral-200" />
+          <div className="leading-tight">
+            <div className="text-xs font-semibold text-neutral-900">{title}</div>
+            <div className="text-[11px] text-neutral-500">{artist}</div>
+          </div>
+        </div>
 
-      {/* 우: bookmark/like */}
-      <div className="flex items-center gap-2">
-        <IconButton ariaLabel="찜" variant="ghost">
-          <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
-            <path
-              fillRule="evenodd"
-              d="M10 2c-1.716 0-3.408.106-5.07.31C3.806 2.45 3 3.414 3 4.517V17.25a.75.75 0 0 0 1.075.676L10 15.082l5.925 2.844A.75.75 0 0 0 17 17.25V4.517c0-1.103-.806-2.068-1.93-2.207A41.403 41.403 0 0 0 10 2Z"
-              clipRule="evenodd"
-            />
-          </svg>
-        </IconButton>
-
-        <IconButton ariaLabel="좋아요" variant="ghost">
-          <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
-            <path d="m9.653 16.915-.005-.003-.019-.01a20.759 20.759 0 0 1-1.162-.682 22.045 22.045 0 0 1-2.582-1.9C4.045 12.733 2 10.352 2 7.5a4.5 4.5 0 0 1 8-2.828A4.5 4.5 0 0 1 18 7.5c0 2.852-2.044 5.233-3.885 6.82a22.049 22.049 0 0 1-3.744 2.582l-.019.01-.005.003h-.002a.739.739 0 0 1-.69.001l-.002-.001Z" />
-          </svg>
-        </IconButton>
+        {/* 우: bookmark/like */}
+         <div className="flex items-center gap-2">
+                <IconButton ariaLabel="찜" variant="ghost">
+                  <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
+                    <path
+                      fillRule="evenodd"
+                      d="M10 2c-1.716 0-3.408.106-5.07.31C3.806 2.45 3 3.414 3 4.517V17.25a.75.75 0 0 0 1.075.676L10 15.082l5.925 2.844A.75.75 0 0 0 17 17.25V4.517c0-1.103-.806-2.068-1.93-2.207A41.403 41.403 0 0 0 10 2Z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </IconButton>
+        
+                <IconButton ariaLabel="좋아요" variant="ghost">
+                  <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
+                    <path d="m9.653 16.915-.005-.003-.019-.01a20.759 20.759 0 0 1-1.162-.682 22.045 22.045 0 0 1-2.582-1.9C4.045 12.733 2 10.352 2 7.5a4.5 4.5 0 0 1 8-2.828A4.5 4.5 0 0 1 18 7.5c0 2.852-2.044 5.233-3.885 6.82a22.049 22.049 0 0 1-3.744 2.582l-.019.01-.005.003h-.002a.739.739 0 0 1-.69.001l-.002-.001Z" />
+                  </svg>
+                </IconButton>
+          </div>
       </div>
     </div>
   );

--- a/components/molecules/TypingControlBar.tsx
+++ b/components/molecules/TypingControlBar.tsx
@@ -1,0 +1,37 @@
+import { IconButton } from "../atoms/IconButton"
+export default function TypingControlBar(){
+    return (
+        <div className="flex items-center justify-center">
+            <div className="flex items-center gap-3">
+                <IconButton ariaLabel="처음으로" variant="ghost">
+                  {/* refresh */}
+                  <svg viewBox="0 0 24 24" className="size-5" fill="currentColor">
+                    <path d="M19.146 4.854l-1.489 1.489A8 8 0 1 0 12 20a8.094 8.094 0 0 0 7.371-4.886 1 1 0 1 0-1.842-.779A6.071 6.071 0 0 1 12 18a6 6 0 1 1 4.243-10.243l-1.39 1.39a.5.5 0 0 0 .354.854H19.5A.5.5 0 0 0 20 9.5V5.207a.5.5 0 0 0-.854-.353z" />
+                  </svg>
+                </IconButton>
+        
+                <div className="flex items-center gap-2">
+                  {/* <IconButton ariaLabel="이전">
+                    <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
+                      <path
+                        fillRule="evenodd"
+                        d="M11.78 5.22a.75.75 0 0 1 0 1.06L8.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </IconButton> */}
+        
+                  <IconButton ariaLabel="다음" variant="ghost">
+                    <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
+                      <path
+                        fillRule="evenodd"
+                        d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </IconButton>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/components/molecules/TypingDisplay.tsx
+++ b/components/molecules/TypingDisplay.tsx
@@ -123,7 +123,7 @@ export function TypingDisplay({ text, input, cursorIndex, isComposing }: TypingD
     composingInputIndex >= 0 ? parsed.inputToExtra[composingInputIndex] : null;
 
   return (
-    <div className="flex flex-wrap gap-[2px] text-lg leading-7">
+    <div className="flex flex-wrap gap-[2px] text-[20px] leading-[30px]">
       {safeText.split("").map((char, index) => {
         const state = parsed.states[index];
         const typed = parsed.typedAt[index];
@@ -135,7 +135,7 @@ export function TypingDisplay({ text, input, cursorIndex, isComposing }: TypingD
 
         let color = "text-neutral-400";
         if (state === "correct") color = "text-neutral-900";
-        if (state === "wrong") color = "text-red-500";
+        if (state === "wrong") color = "text-[#fb4058]";
 
         // 조합 중인 “진짜 그 칸”이면 빨강 금지
         if (isComposing && index === composingTextIndex) {
@@ -145,7 +145,7 @@ export function TypingDisplay({ text, input, cursorIndex, isComposing }: TypingD
         return (
           <span key={index}>
             {isCursorHere && (
-              <span className="inline-block w-[2px] h-[1.3em] bg-blue-500 align-middle animate-pulse mr-[1px]" />
+              <span className="inline-block w-[2px] h-[1.45em] bg-[#fb4058] align-middle typing-cursor mr-[1px]" />
             )}
 
             {/* space 자리의 extra를 글자 단위로 렌더(조합중 1글자만 검정) */}
@@ -160,7 +160,7 @@ export function TypingDisplay({ text, input, cursorIndex, isComposing }: TypingD
                   return (
                     <span
                       key={ei}
-                      className={isComposingExtraHere ? "text-neutral-900" : "text-red-500"}
+                      className={isComposingExtraHere ? "text-neutral-900" : "text-[#fb4058]"}
                     >
                       {c}
                     </span>
@@ -175,7 +175,7 @@ export function TypingDisplay({ text, input, cursorIndex, isComposing }: TypingD
       })}
 
       {effectiveCursor === safeText.length && (
-        <span className="inline-block w-[2px] h-[1.3em] bg-blue-500 align-middle animate-pulse ml-[1px]" />
+        <span className="inline-block w-[2px] h-[1.45em] bg-[#fb4058] align-middle typing-cursor ml-[1px]" />
       )}
     </div>
   );

--- a/components/molecules/TypingTopBar.tsx
+++ b/components/molecules/TypingTopBar.tsx
@@ -1,43 +1,22 @@
 "use client";
 
-import { ProgressBar } from "../atoms/ProgressBar";
 import { StatItem } from "../atoms/StatItem";
-
 type Props = {
-  title: string;
-  artist: string;
   wpm: number;
   cpm: number;
   acc: number;
-  progress: number;
-};
-
-export function TypingTopBar({ title, artist, wpm, cpm, acc, progress }: Props) {
+}
+export function TypingTopBar({wpm, cpm, acc}: Props) {
   return (
-    <div className="px-4 py-3">
-      <div className="flex items-start justify-between gap-4">
-        {/* 좌: 메타 */}
-        <div className="flex items-center gap-3">
-          <div className="h-10 w-10 rounded-md bg-neutral-200" />
-          <div className="leading-tight">
-            <div className="text-xs font-semibold text-neutral-900">{title}</div>
-            <div className="text-[11px] text-neutral-500">{artist}</div>
-          </div>
-        </div>
-
-        {/* 우: stats */}
-        <div className="flex items-center gap-3 text-xs text-neutral-600">
+    <div className="flex items-center justify-end bg-neutral-200 border border-neutral-200 rounded-lg px-4 py-3">
+      {/* 우: stats*/}
+       <div className="flex items-center gap-3 text-xs text-neutral-600">
           <StatItem label="WPM" value={wpm} />
           <div className="h-7 w-px bg-neutral-200" />
           <StatItem label="CPM" value={cpm} />
           <div className="h-7 w-px bg-neutral-200" />
           <StatItem label="ACC" value={`${acc}%`} />
         </div>
-      </div>
-
-      <div className="mt-3">
-        <ProgressBar value={progress} />
-      </div>
     </div>
   );
 }

--- a/components/organisms/SongTypeBoard.tsx
+++ b/components/organisms/SongTypeBoard.tsx
@@ -6,6 +6,7 @@ import { TypingStage } from "../molecules/TypingStage";
 import { TypingTopBar } from "../molecules/TypingTopBar";
 import { useLiveTypingMetrics } from "@/hooks/useLiveTypingMetrics";
 import { ResultModal } from "../molecules/ResultModal";
+import TypingControlBar from "../molecules/TypingControlBar";
 type Props = {
   song: {
     songId: number;
@@ -55,35 +56,48 @@ export function SongTypeBoard({ song }: Props) {
   }, [isComposing, isFinished, metrics.wpm, metrics.cpm, metrics.acc]);
  
   return (
-    <div className="w-full max-w-4xl rounded-xl border border-neutral-300 bg-white shadow-lg">
+    <div className="w-full max-w-4xl ">
       {/* =======================
           상단: 타이틀 + Stats + Progress
          ======================= */}
-      <TypingTopBar 
-        title={song.title}
-        artist={song.artist}
-        wpm={wpm}
-        cpm={cpm}
-        acc={acc}
-        progress={progress}
-      />
-      {/* =======================
-          중앙: 타이핑 영역
-         ======================= */}
-        <TypingStage
-          text={text}
-          input={input}
-          cursorIndex={cursorIndex}
-          onFocusRequest={focusInput}
-          inputRef={inputRef}
-          onChangeInput={setInput}
-          isComposing={isComposing}
-          onComposingChange={setIsComposing}
-        />     
+      <div className="mb-16">
+        <TypingTopBar wpm={wpm} cpm={cpm} acc={acc}/>
+      </div>
+       <div className="space-y-6">
+        <div className="space-y-6">
+           {/* =======================
+                중앙: 타이핑 영역
+            ======================= */}
+            <TypingStage
+              text={text}
+              input={input}
+              cursorIndex={cursorIndex}
+              onFocusRequest={focusInput}
+              inputRef={inputRef}
+              onChangeInput={setInput}
+              isComposing={isComposing}
+              onComposingChange={setIsComposing}
+            />     
+            {/* =======================
+              중앙 : 컨트롤 바
+            ======================= */}
+            <TypingControlBar />
+        </div>
          {/* =======================
           하단: 메타정보(이미지) + 버튼들
          ======================= */}
-        <TypingBottomBar />
+         <div className="pt-6">
+          <TypingBottomBar 
+              title={song.title}
+              artist={song.artist}
+              wpm={wpm}
+              cpm={cpm}
+              acc={acc}
+              progress={progress}
+            />
+         </div>
+       </div>
+        
          {/* =======================
            결과 모달
          ======================= */}
@@ -92,6 +106,6 @@ export function SongTypeBoard({ song }: Props) {
           result={result}
           onClose={() => setIsResultOpen(false)}
         />
-    </div>
+        </div>
   );
 }


### PR DESCRIPTION
타이핑 화면의 UI 구조를 정리하고 가사 영역 가독성을 개선했습니다.

- WPM/CPM/ACC를 TopBar로 이동하여 정보 영역 분리
- 가사 영역과 컨트롤 바를 하나의 흐름으로 묶어 조작 집중도 향상
- 가사 텍스트 크기 및 줄 간격 조정으로 읽기 편한 레이아웃 구성
- 커서 색상 변경