### PR TITLE
feat: 곡 리스트 기반 타이핑 렌더링 및 곡 전환 기능 추가

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,38 +1,52 @@
-import Image from "next/image";
 import { SongTypeBoard } from "@/components/organisms/SongTypeBoard";
-export type Song = {
-  songId: number;
-  title: string;
-  artist: string;
-  lyrice: string;
-}
+import { Song } from "@/types/song";
 
-async function getSong(id: number): Promise<Song>{
-  const API_BASE_URL = process.env.NEXT_PUBLIC_API_POSTMAN_URL!;
-  const res = await fetch(
-    `${API_BASE_URL}`,
-    {
-      // 개발 중엔 매번 새로 가져오고 싶으면:
-      cache: "no-store",
-    }
-  )
-  if(!res.ok){
-    throw new Error("Failed to fetch song");
+type ApiSong = {
+  id: number;
+  title: string;
+  author: string;
+  content: string;
+  genre: string;
+  image_url: string;
+};
+
+type ApiResponse<T> = {
+  data: T;
+  success: boolean;
+  error: string | null;
+};
+
+async function getSongs(): Promise<Song[]> {
+  const API_BASE_URL = `${process.env.API_BASE_URL}/text/main`;
+
+  const res = await fetch(API_BASE_URL, {
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    throw new Error("Failed to fetch songs");
   }
-  return res.json();
+
+  const json: ApiResponse<ApiSong[]> = await res.json();
+
+  if (!json.success) {
+    throw new Error(json.error ?? "API error");
+  }
+
+  return json.data.map((item) => ({
+    songId: item.id,
+    title: item.title,
+    artist: item.author,
+    lyric: item.content,
+    imageUrl: item.image_url,
+  }));
 }
 export default async function Home() {
-  const song = await getSong(1);
-  const DUMMY_SONG: Song = {
-    songId: 1,
-    title: "Dummy Song",
-    artist: "Test Artist",
-    lyrice: "오늘도 나는 키보드를 두드린다. 오늘도 나는 키보드를 두드린다. 오늘도 나는 키보드를 두드린다",
-  };
+  const songs = await getSongs();
   
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-neutral-100">
-      <SongTypeBoard song={DUMMY_SONG}/>
+      <SongTypeBoard songs={songs}/>
     </div>
   );
 }

--- a/components/atoms/IconButton.tsx
+++ b/components/atoms/IconButton.tsx
@@ -4,17 +4,31 @@ type Props = {
     children: ReactNode;
     ariaLabel: string;
     onClick?: () => void;
+    disabled?: boolean; 
     variant?: "default" | "ghost";
 }
-export function IconButton({children, ariaLabel, onClick, variant = "default"}: Props){
+export function IconButton({
+    children, 
+    ariaLabel, 
+    onClick, 
+    disabled = false,
+    variant = "default"
+}: Props){
     const variantStyle = variant === "default" ? "rounded-full border border-neutral-200 " : ""
     return (
         <button 
             type="button"
             aria-label={ariaLabel}
             onClick={onClick}
-            className={`h-7 w-7 grid place-items-center text-neutral-800 hover:bg-neutral-50 ${variantStyle}`} 
-            >
+            disabled={disabled}
+            className={[
+                "h-7 w-7 grid place-items-center",
+                "text-neutral-800",
+                "hover:bg-neutral-50",
+                "disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent",
+                variantStyle,
+              ].join(" ")}
+        >
             {children}
         </button>
     )

--- a/components/molecules/TypingBottomBar.tsx
+++ b/components/molecules/TypingBottomBar.tsx
@@ -2,16 +2,19 @@
 
 import { ProgressBar } from "../atoms/ProgressBar";
 import { IconButton } from "../atoms/IconButton";
+import Image from "next/image";
+
 type Props = {
   title: string;
   artist: string;
+  imageUrl: string;
   wpm: number;
   cpm: number;
   acc: number;
   progress: number;
 };
 
-export function TypingBottomBar({ title, artist, progress }: Props) {
+export function TypingBottomBar({ title, artist, imageUrl, progress }: Props) {
   return (
     <div className="px-4 py-3">
        <div className="mb-3">
@@ -20,7 +23,15 @@ export function TypingBottomBar({ title, artist, progress }: Props) {
       <div className="flex items-start justify-between gap-4">
         {/* 좌: 메타 */}
         <div className="flex items-center gap-3">
-          <div className="h-10 w-10 rounded-md bg-neutral-200" />
+        <div className="h-10 w-10 shrink-0 relative overflow-hidden rounded-md bg-neutral-200">
+            <Image
+              src={imageUrl}
+              alt={`${title} cover`}
+              fill
+              className="object-cover"
+              sizes="40px"
+            />
+          </div>
           <div className="leading-tight">
             <div className="text-xs font-semibold text-neutral-900">{title}</div>
             <div className="text-[11px] text-neutral-500">{artist}</div>

--- a/components/molecules/TypingControlBar.tsx
+++ b/components/molecules/TypingControlBar.tsx
@@ -1,37 +1,43 @@
-import { IconButton } from "../atoms/IconButton"
-export default function TypingControlBar(){
-    return (
-        <div className="flex items-center justify-center">
-            <div className="flex items-center gap-3">
-                <IconButton ariaLabel="처음으로" variant="ghost">
-                  {/* refresh */}
-                  <svg viewBox="0 0 24 24" className="size-5" fill="currentColor">
-                    <path d="M19.146 4.854l-1.489 1.489A8 8 0 1 0 12 20a8.094 8.094 0 0 0 7.371-4.886 1 1 0 1 0-1.842-.779A6.071 6.071 0 0 1 12 18a6 6 0 1 1 4.243-10.243l-1.39 1.39a.5.5 0 0 0 .354.854H19.5A.5.5 0 0 0 20 9.5V5.207a.5.5 0 0 0-.854-.353z" />
-                  </svg>
-                </IconButton>
-        
-                <div className="flex items-center gap-2">
-                  {/* <IconButton ariaLabel="이전">
-                    <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
-                      <path
-                        fillRule="evenodd"
-                        d="M11.78 5.22a.75.75 0 0 1 0 1.06L8.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06l-4.25-4.25a.75.75 0 0 1 0-1.06l4.25-4.25a.75.75 0 0 1 1.06 0Z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </IconButton> */}
-        
-                  <IconButton ariaLabel="다음" variant="ghost">
-                    <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
-                      <path
-                        fillRule="evenodd"
-                        d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </IconButton>
-                </div>
-            </div>
+import { IconButton } from "../atoms/IconButton";
+
+type Props = {
+  onReset?: () => void;
+  onNext?: () => void;
+  disableNext?: boolean;
+};
+
+export default function TypingControlBar({
+  onReset,
+  onNext,
+  disableNext,
+}: Props) {
+  return (
+    <div className="flex items-center justify-center">
+      <div className="flex items-center gap-3">
+        <IconButton ariaLabel="처음으로" variant="ghost" onClick={onReset}>
+          {/* refresh svg 그대로 */}
+          <svg viewBox="0 0 24 24" className="size-5" fill="currentColor">
+            <path d="M19.146 4.854l-1.489 1.489A8 8 0 1 0 12 20a8.094 8.094 0 0 0 7.371-4.886 1 1 0 1 0-1.842-.779A6.071 6.071 0 0 1 12 18a6 6 0 1 1 4.243-10.243l-1.39 1.39a.5.5 0 0 0 .354.854H19.5A.5.5 0 0 0 20 9.5V5.207a.5.5 0 0 0-.854-.353z" />
+          </svg>
+        </IconButton>
+
+        <div className="flex items-center gap-2">
+          <IconButton
+            ariaLabel="다음"
+            variant="ghost"
+            onClick={onNext}
+            disabled={disableNext}
+          >
+            <svg viewBox="0 0 20 20" className="size-5" fill="currentColor">
+              <path
+                fillRule="evenodd"
+                d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </IconButton>
         </div>
-    )
+      </div>
+    </div>
+  );
 }

--- a/components/molecules/TypingDisplay.tsx
+++ b/components/molecules/TypingDisplay.tsx
@@ -43,6 +43,14 @@ function parseTyping(text: string, input: string, maxExtra = 5): Parsed {
     const t = text[i];
     const u = input[j];
 
+    if (t === "\n") {
+      states[i] = "correct";
+      typedAt[i] = null;
+      i++;
+      continue;
+    }
+  
+
     if (t === " ") {
       if (u === " ") {
         states[i] = "correct";
@@ -106,7 +114,9 @@ function parseTyping(text: string, input: string, maxExtra = 5): Parsed {
     inputToExtra,
   };
 }
-
+function normalizeLyric(raw: string) {
+  return raw.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
 export function TypingDisplay({
   text,
   input,
@@ -124,8 +134,8 @@ export function TypingDisplay({
     ? "text-[24px] leading-[36px]"
     : "text-[20px] leading-[30px]"; // md (default)
   
-    const safeText = text ?? "";
-  const parsed = parseTyping(safeText, input, 5);
+    const safeText = normalizeLyric(text ?? ""); 
+    const parsed = parseTyping(safeText, input, 5);
   const effectiveCursor = parsed.cursorIndex;
 
   const composingInputIndex = isComposing ? input.length - 1 : -1;
@@ -143,6 +153,9 @@ export function TypingDisplay({
       ].join(" ")}
     >
       {safeText.split("").map((char, index) => {
+        if (char === "\n") {
+          return <span key={index} className="w-full block h-4" />;
+        }
         const state = parsed.states[index];
         const typed = parsed.typedAt[index];
         const extra = parsed.extrasBeforeSpace[index];

--- a/components/organisms/LyricsListSidebar.tsx
+++ b/components/organisms/LyricsListSidebar.tsx
@@ -2,25 +2,16 @@
 
 import { SidebarShell } from "../organisms/SidebarShell";
 import { IconButton } from "../atoms/IconButton";
-
-type LyricsItem = {
-  id: number;
-  title: string;
-  singer: string;
-};
-
-const MOCK_ITEMS: LyricsItem[] = Array.from({ length: 9 }).map((_, i) => ({
-  id: i + 1,
-  title: "으르렁",
-  singer: "엑소",
-}));
+import { Song } from "@/types/song";
+import Image from "next/image";
 
 type Props = {
   open: boolean;
   onClose: () => void;
+  songs: Song[];
 };
 
-export function LyricsListSidebar({ open, onClose }: Props) {
+export function LyricsListSidebar({ open, onClose, songs }: Props) {
   return (
     <SidebarShell
       open={open}
@@ -29,9 +20,9 @@ export function LyricsListSidebar({ open, onClose }: Props) {
       header={<h2 className="text-lg font-semibold">Current List</h2>}
     >
       <div className="border-t border-neutral-200">
-        {MOCK_ITEMS.map((item, idx) => (
+        {songs.map((item, idx) => (
           <div
-            key={item.id}
+            key={item.songId}
             className="flex items-center border-b border-neutral-200"
           >
             {/* index */}
@@ -40,8 +31,16 @@ export function LyricsListSidebar({ open, onClose }: Props) {
             </div>
 
             {/* image placeholder */}
-            <div className="w-12 h-12 shrink-0 bg-neutral-200 rounded-sm" />
-
+            <div className="w-12 h-12 shrink-0 relative overflow-hidden rounded-sm bg-neutral-200">
+              <Image 
+                src={item.imageUrl}
+                alt={`${item.title} cover`}
+                fill
+                className="object-cover"
+                sizes="48px"
+              />
+            </div>
+            
             {/* content */}
             <button
               type="button"
@@ -51,7 +50,7 @@ export function LyricsListSidebar({ open, onClose }: Props) {
                 {item.title}
               </div>
               <div className="mt-1 text-xs text-neutral-700">
-                {item.singer}
+                {item.artist}
               </div>
             </button>
 

--- a/components/organisms/SongTypeBoard.tsx
+++ b/components/organisms/SongTypeBoard.tsx
@@ -9,23 +9,21 @@ import { ResultModal } from "../molecules/ResultModal";
 import TypingControlBar from "../molecules/TypingControlBar";
 import { SettingsSidebar } from "./SettingsSidebar";
 import { LyricsListSidebar } from "./LyricsListSidebar";
+import { Song } from "@/types/song";
 type Props = {
-  song: {
-    songId: number;
-    title: string;
-    artist: string;
-    lyrice: string;
-  };
-};
+  songs: Song[];
+}
 
 type Result = { wpm: number; cpm: number; acc: number };
 
-export function SongTypeBoard({ song }: Props) {
+export function SongTypeBoard({ songs }: Props) {
   const [input, setInput] = useState("");
   const [isComposing, setIsComposing] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isLyricsListOpen, setIsLyricsListOpen] = useState(false);
-  const text = song?.lyrice ?? "가사가 없습니다(디버깅용)";
+  const [songIndex, setSongIndex] = useState(0);
+  const song = songs[songIndex];
+  const text = song?.lyric ?? "가사가 없습니다(디버깅용)";
 
   const inputRef = useRef<HTMLInputElement | null>(null);
   const focusInput = () => inputRef.current?.focus();
@@ -43,6 +41,29 @@ export function SongTypeBoard({ song }: Props) {
   const [result, setResult] = useState<Result | null>(null);
   const isFinished = input.length >= text.length; // normalize 정책이면 필요시 더 엄격히
 
+  /// 컨트롤바로 조작 로직
+  const canNext = songIndex < songs.length - 1;
+
+  const resetForSong = () => {
+    setInput("");
+    setIsComposing(false);
+    setIsResultOpen(false);
+    setResult(null);
+    resetMetrics();
+    focusInput();
+  };
+
+  const goNextSong = () => {
+    if (!canNext) return;
+    setSongIndex((i) => i + 1);
+  };
+  /// 컨트롤바로 조작 로직 end
+
+  useEffect(() => {
+    resetForSong();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [songIndex]);
+
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key !== "Enter") return;
@@ -59,6 +80,9 @@ export function SongTypeBoard({ song }: Props) {
     return () => window.removeEventListener("keydown", onKeyDown);
   }, [isComposing, isFinished, metrics.wpm, metrics.cpm, metrics.acc]);
  
+  if(!songs || songs.length === 0) {
+    return <div className="w-full max-w-4xl">곡이 없습니다.</div>
+  }
   return (
     <div className="w-full max-w-4xl ">
       {/* =======================
@@ -91,8 +115,12 @@ export function SongTypeBoard({ song }: Props) {
             {/* =======================
               중앙 : 컨트롤 바
             ======================= */}
-            <TypingControlBar />
-        </div>
+            <TypingControlBar
+              onReset={resetForSong}
+              onNext={goNextSong}
+              disableNext={!canNext}
+            />       
+         </div>
          {/* =======================
           하단: 메타정보(이미지) + 버튼들
          ======================= */}
@@ -100,6 +128,7 @@ export function SongTypeBoard({ song }: Props) {
           <TypingBottomBar 
               title={song.title}
               artist={song.artist}
+              imageUrl={song.imageUrl}
               wpm={wpm}
               cpm={cpm}
               acc={acc}
@@ -129,6 +158,7 @@ export function SongTypeBoard({ song }: Props) {
          <LyricsListSidebar 
           open={isLyricsListOpen}
           onClose={() => setIsLyricsListOpen(false)}
+          songs={songs}
          />
         </div>
   );

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,7 +6,12 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
-        hostname: "lh3.googleusercontent.com",
+        hostname: "lh3.googleusercontent.com", 
+      },
+      {
+        protocol: "https",
+        hostname: "typing-game-images.s3.ap-northeast-2.amazonaws.com",
+        pathname: "/**",
       },
     ],
   },

--- a/types/song.ts
+++ b/types/song.ts
@@ -1,0 +1,7 @@
+export type Song = {
+    songId: number;
+    title: string;
+    artist: string;
+    lyric: string;
+    imageUrl: string;
+};


### PR DESCRIPTION
- /text/main API로 여러 곡을 받아 렌더링하도록 구조 변경
- SongTypeBoard를 단일 곡 → 곡 배열 기반으로 리팩토링
- 화살표 버튼으로 다음 곡 전환 기능 구현
- 가사 개행(\r\n) 처리 및 줄바꿈 렌더링 개선
- 사이드바/하단 메타 영역에 곡 이미지 연동