### PR TITLE
feat: 최근 타이핑 기록 섹션 및 세션 로우 추가

### DIFF
--- a/components/molecules/mypage/SessionRow.tsx
+++ b/components/molecules/mypage/SessionRow.tsx
@@ -1,0 +1,45 @@
+import { RecentSession } from "@/app/my/page";
+export function SessionRow({ s }: { s: RecentSession }) {
+
+  return (
+    <li className="flex items-center gap-4 px-5 py-4 hover:bg-neutral-50">
+      {/* cover */}
+      <div className="w-10 h-10 flex-shrink-0 overflow-hidden rounded-lg bg-neutral-100">
+        {s.imageUrl ? (
+          <img
+            src={s.imageUrl}
+            alt={s.title}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="h-full w-full bg-neutral-200" />
+        )}
+      </div>      
+      {/* text */}
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-semibold text-neutral-900">
+          {s.title} <span className="text-neutral-400">·</span> {s.author}
+        </div>
+        <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-neutral-500">
+          <span>{s.playedAt}</span>
+        </div>
+      </div>
+      {/* stats */}
+      <div className="hidden sm:flex items-center gap-2">
+        <div className="rounded-xl border border-neutral-200 bg-white px-3 py-2 text-xs font-semibold tabular-nums text-neutral-800">
+          {s.wpm} WPM
+        </div>
+        <div className="rounded-xl border border-neutral-200 bg-white px-3 py-2 text-xs font-semibold tabular-nums text-neutral-800">
+          {s.accuracy.toFixed(1)}%
+        </div>
+        <div className="rounded-xl border border-neutral-200 bg-white px-3 py-2 text-xs font-semibold tabular-nums text-neutral-800">
+          x{s.combo}
+        </div>
+      </div>
+      {/* action */}
+      <button className="ml-2 rounded-xl border border-neutral-200 bg-white px-3 py-2 text-xs font-semibold text-neutral-700 hover:bg-neutral-50">
+        상세
+      </button>
+    </li>
+  );
+}

--- a/components/organisms/RecentResultSection.tsx
+++ b/components/organisms/RecentResultSection.tsx
@@ -1,0 +1,19 @@
+import { SessionRow } from "../molecules/mypage/SessionRow"
+import { RecentSession } from "@/app/my/page"
+export function RecentResultSection({recentResults}: {recentResults: RecentSession[]}){
+    return (
+         <div className="min-w-0 overflow-hidden">
+            <div className="flex items-center justify-between border-b border-neutral-200 px-5 py-4">
+                <div className="text-sm font-semibold text-neutral-900">최근 타이핑 기록</div>
+                <button className="text-xs font-semibold text-neutral-600 hover:text-neutral-900">
+                    전체 보기
+                </button>
+            </div>
+            <ul className="divide-y divide-neutral-200">
+                {recentResults.map((s) => (
+                    <SessionRow key={s.resultId} s={s} />
+                ))}
+            </ul>
+        </div>      
+    )
+}


### PR DESCRIPTION
- 마이페이지에서 최근 타이핑 결과 데이터를 서버에서 페치하도록 구현
- API 응답을 UI 전용 타입(RecentSession)으로 가공하여 사용
- SessionRow(molecule), 최근 결과 섹션(organism)으로 컴포넌트 구조 분리
- 이미지, 타이틀, 작성자, 지표(WPM/정확도/콤보) 중심으로 UI 구성