### PR TITLE
feat: 리더보드 마이랭크 연동 및 Me 타입 통합

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -1,35 +1,34 @@
 // app/leaderboard/page.tsx
-import React from "react";
+import { MyRankSideCard } from "@/components/organisms/MyRankSideCard";
+import { authOptions } from "../api/auth/[...nextauth]/authOption";
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { getMe } from "@/lib/api/user";
 
-type Leader = {
+export type Leader = {
   rank: number;
   name: string;
   handle: string;
+  imageUrl: string | null;
   wpm: number;
   accuracy: number; // 0~100
   combo: number;
 };
 
-const top3: Leader[] = [
-  { rank: 1, name: "MinSung", handle: "@minsung", wpm: 128, accuracy: 98.4, combo: 42 },
-  { rank: 2, name: "JungMin", handle: "@jungmin", wpm: 121, accuracy: 97.1, combo: 31 },
-  { rank: 3, name: "Hyun", handle: "@hyun", wpm: 118, accuracy: 96.7, combo: 27 },
-];
-
 const rest: Leader[] = Array.from({ length: 20 }).map((_, i) => {
-  const rank = i + 4;
+  const rank = i + 1;
   return {
     rank,
     name: `User ${rank}`,
     handle: `@user${rank}`,
+    imageUrl: 'imsi',
     wpm: 112 - i,
     accuracy: Math.max(90, 96 - i * 0.2),
     combo: Math.max(3, 25 - i),
   };
 });
-
 // 내 랭킹(더미)
-const myRank: Leader = { rank: 17, name: "You", handle: "@me", wpm: 104, accuracy: 94.3, combo: 18 };
+// const myRank: Leader = { rank: 17, name: "You", handle: "@me", wpm: 104, accuracy: 94.3, combo: 18 };
 
 function Crown() {
   return (
@@ -134,59 +133,6 @@ function CompactPodiumCard({ leader, emphasize }: { leader: Leader; emphasize?: 
   );
 }
 
-/** 데스크탑 왼쪽 사이드에 두는 My Rank 카드(가리지 않음 + sticky) */
-function MyRankSideCard({ me }: { me: Leader }) {
-  return (
-    <div className="border border-neutral-200 p-4 rounded-2xl bg-white">
-      <div className="flex items-start justify-between">
-        <div className="text-xs font-semibold text-neutral-500">MY RANK</div>
-        <div className="rounded-full border border-neutral-200 bg-neutral-50 px-3 py-1 text-xs font-semibold text-neutral-800 tabular-nums">
-          #{me.rank}
-        </div>
-      </div>
-
-      <div className="mt-4 flex items-center gap-3">
-        <Avatar name={me.name} />
-        <div className="min-w-0">
-          <div className="truncate text-base font-semibold text-neutral-900">{me.name}</div>
-          <div className="truncate text-sm text-neutral-500">{me.handle}</div>
-        </div>
-      </div>
-
-      <div className="mt-4 grid grid-cols-3 gap-2">
-        <div className="rounded-xl border border-neutral-200 bg-white px-3 py-2">
-          <div className="text-[11px] font-medium text-neutral-500">WPM</div>
-          <div className="mt-0.5 text-sm font-semibold text-neutral-900 tabular-nums">{me.wpm}</div>
-        </div>
-        <div className="rounded-xl border border-neutral-200 bg-white px-3 py-2">
-          <div className="text-[11px] font-medium text-neutral-500">ACC</div>
-          <div className="mt-0.5 text-sm font-semibold text-neutral-900 tabular-nums">{me.accuracy.toFixed(1)}%</div>
-        </div>
-        <div className="rounded-xl border border-neutral-200 bg-white px-3 py-2">
-          <div className="text-[11px] font-medium text-neutral-500">COMBO</div>
-          <div className="mt-0.5 text-sm font-semibold text-neutral-900 tabular-nums">x{me.combo}</div>
-        </div>
-      </div>
-
-      <div className="mt-4">
-        <div className="flex items-center justify-between text-[11px] text-neutral-500">
-          <span>Accuracy</span>
-          <span className="tabular-nums">{me.accuracy.toFixed(1)}%</span>
-        </div>
-        <ProgressBar value={me.accuracy} />
-      </div>
-
-      <button className="mt-5 w-full rounded-xl bg-neutral-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-neutral-800">
-        내 기록 보기
-      </button>
-
-      <div className="mt-3 text-xs text-neutral-500">
-        * 리더보드는 WPM/정확도/콤보를 종합해 정렬될 수 있어요.
-      </div>
-    </div>
-  );
-}
-
 /** 모바일에서는 왼쪽 사이드가 없으니, 위쪽에 “일반 카드”로 한 번만 보여주기 */
 function MyRankMobileCard({ me }: { me: Leader }) {
   return (
@@ -275,33 +221,42 @@ function Row({ u, highlight }: { u: Leader; highlight?: boolean }) {
     );
 }
 
-export default function LeaderboardPage() {
+export default async function LeaderboardPage() {
+    const session = await getServerSession(authOptions);
+  
+    const userId = (session?.user as any)?.user_id;
+    const me = await getMe(Number(userId));
+  
+    const myRank: Leader | null = me 
+    ? {
+      rank: 0, // TODO: 서버에서 내려주면 교체
+      name: me.name,
+      handle: me.handle,
+      imageUrl: me.image,
+      wpm: 0, // TODO: 서버 통계 붙으면 교체
+      accuracy: me.avg_accuracy ?? 0,
+      combo: me.max_combo ?? 0,
+    }
+    : null;
   return (
     <main className="min-h-screen bg-neutral-100">
       <div className="mx-auto w-full max-w-6xl px-4 py-10">
         {/* mobile my rank */}
         <div className="mt-6">
-          <MyRankMobileCard me={myRank} />
+          {myRank && (<MyRankMobileCard me={myRank} />)}
         </div>
 
         {/* desktop layout: left my-rank + right content */}
         <div className="mt-6 grid gap-6 md:grid-cols-[320px_1fr]">
           {/* left (desktop only) */}
           <aside className="hidden md:block">
-            <div className="sticky top-6">
-              <MyRankSideCard me={myRank} />
+            <div className="sticky top-[88px]">
+              {myRank && (<MyRankSideCard me={myRank} />)}
             </div>
           </aside>
 
           {/* right */}
           <section className="min-w-0">
-            {/* podium (compact) */}
-            <div className="grid gap-3 md:grid-cols-3">
-              <CompactPodiumCard leader={top3[1]} />
-              <CompactPodiumCard leader={top3[0]} emphasize />
-              <CompactPodiumCard leader={top3[2]} />
-            </div>
-
             {/* list */}
             <div className="mt-6 border-b border-neutral-200">
               <div className="flex items-center justify-between border-b border-neutral-200 px-5 py-4">
@@ -311,7 +266,7 @@ export default function LeaderboardPage() {
 
               <ul className="divide-y divide-neutral-200">
                 {rest.map((u) => (
-                  <Row key={u.rank} u={u} highlight={u.rank === myRank.rank} />
+                  <Row key={u.rank} u={u} highlight={u.rank === (myRank?.rank ?? -1)} />
                 ))}
               </ul>
             </div>

--- a/components/organisms/MyRankSideCard.tsx
+++ b/components/organisms/MyRankSideCard.tsx
@@ -1,0 +1,59 @@
+import { Avatar } from "../atoms/mypage/Avatar";
+import { Leader } from "@/app/leaderboard/page";
+
+export function MyRankSideCard({ me }: { me: Leader }) {
+    return (
+      <div className="border border-neutral-200 p-4 rounded-2xl bg-white">
+        <div className="flex items-start justify-between">
+          <div className="text-xs font-semibold text-neutral-500">MY RANK</div>
+          <div className="rounded-full border border-neutral-200 bg-neutral-50 px-3 py-1 text-xs font-semibold text-neutral-800 tabular-nums">
+            #{me.rank}
+          </div>
+        </div>
+  
+        <div className="mt-4 flex items-center gap-3">
+        <div className="h-12 w-12 shrink-0 overflow-hidden rounded-full">
+            {me.imageUrl ? (
+                <img
+                  src={me.imageUrl}
+                  alt={me.name}
+                  className="h-full w-full object-cover"
+                />
+            ) : (
+                    <div className="flex h-full w-full items-center justify-center text-sm font-semibold text-neutral-500">
+                        {me.name[0]}
+                    </div>
+                ) }          
+            </div>
+          <div className="min-w-0">
+            <div className="truncate text-base font-semibold text-neutral-900">{me.name}</div>
+            <div className="truncate text-sm text-neutral-500">{me.handle}</div>
+          </div>
+        </div>
+  
+        <div className="mt-4 grid grid-cols-3 gap-2">
+          <div className="rounded-xl border border-neutral-200 bg-white px-3 py-2">
+            <div className="text-[11px] font-medium text-neutral-500">WPM</div>
+            <div className="mt-0.5 text-sm font-semibold text-neutral-900 tabular-nums">{me.wpm}</div>
+          </div>
+          <div className="rounded-xl border border-neutral-200 bg-white px-3 py-2">
+            <div className="text-[11px] font-medium text-neutral-500">ACC</div>
+            <div className="mt-0.5 text-sm font-semibold text-neutral-900 tabular-nums">{me.accuracy.toFixed(1)}%</div>
+          </div>
+          <div className="rounded-xl border border-neutral-200 bg-white px-3 py-2">
+            <div className="text-[11px] font-medium text-neutral-500">COMBO</div>
+            <div className="mt-0.5 text-sm font-semibold text-neutral-900 tabular-nums">x{me.combo}</div>
+          </div>
+        </div>
+  
+        <button className="mt-5 w-full rounded-xl bg-neutral-900 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-neutral-800">
+          내 기록 보기
+        </button>
+  
+        <div className="mt-3 text-xs text-neutral-500">
+          * 리더보드는 WPM/정확도/콤보를 종합해 정렬될 수 있어요.
+        </div>
+      </div>
+    );
+  }
+  

--- a/lib/api/user.ts
+++ b/lib/api/user.ts
@@ -1,0 +1,27 @@
+import { Me } from "@/types/me";
+export async function getMe(userId: number): Promise<Me> {
+  const res = await fetch(`${process.env.API_BASE_URL}/user/profile/${userId}`, {
+    cache: "no-store",
+    headers: {
+      // 서버가 내부키 요구하면 유지
+      "X-INTERNAL-KEY": process.env.INTERNAL_SYNC_KEY!,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch profile: ${res.status}`);
+  }
+
+  const json = await res.json();
+
+  return {
+    name: json?.data?.username ?? "Unknown",
+    handle: json?.data?.email ?? `user-${userId}`,
+    tier: json?.data?.tier ?? "Bronze",
+    email: json?.data?.email,
+    image: json?.data?.profile_pic ?? null,
+    avg_accuracy: json?.data?.stats?.avg_accuracy ?? null,
+    max_combo: json?.data?.stats?.max_combo ?? null,
+    play_count: json?.data?.stats?.play_count ?? null,
+  };
+}

--- a/types/me.ts
+++ b/types/me.ts
@@ -1,0 +1,10 @@
+export type Me = {
+    name: string;
+    handle: string;
+    tier: string;
+    email?: string;
+    image: string | null;
+    avg_accuracy: number | null;
+    max_combo: number | null;
+    play_count: number | null;
+  };


### PR DESCRIPTION
- 사용자 프로필(Me) 타입을 공용 타입으로 통합
- 리더보드 MyRank 카드에 사용자 프로필 데이터 연동
- 서버 응답 구조에 맞게 getMe 파싱 로직 수정
- 로그인/비로그인 상태에 따른 안전한 렌더링 처리