### PR TITLE
fix: 유저 프로필 API 응답 구조 변경 반영

### DIFF
--- a/lib/api/user.ts
+++ b/lib/api/user.ts
@@ -1,10 +1,35 @@
 import { Me } from "@/types/me";
+
+type ApiMeResponse = {
+  data: {
+    account: {
+      email: string;
+      profile_pic: string | null;
+      ranking_score: number;
+      user_id: number;
+      username: string;
+    };
+    stats: {
+      avg_accuracy: number;
+      avg_cpm: number;
+      avg_wpm: number;
+      best_cpm: number;
+      best_wpm: number;
+      max_combo: number;
+      play_count: number;
+    };
+  } | null;
+  error: any;
+  success: boolean;
+};
 export async function getMe(userId: number): Promise<Me> {
-  const res = await fetch(`${process.env.API_BASE_URL}/user/profile/${userId}`, {
+  const base = process.env.API_BASE_URL ?? process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (!base) throw new Error("API_BASE_URL env is missing");
+
+  const res = await fetch(`${base}/user/profile/${userId}`, {
     cache: "no-store",
     headers: {
-      // 서버가 내부키 요구하면 유지
-      "X-INTERNAL-KEY": process.env.INTERNAL_SYNC_KEY!,
+      "X-INTERNAL-KEY": process.env.INTERNAL_SYNC_KEY ?? "",
     },
   });
 
@@ -12,16 +37,23 @@ export async function getMe(userId: number): Promise<Me> {
     throw new Error(`Failed to fetch profile: ${res.status}`);
   }
 
-  const json = await res.json();
+  const json: ApiMeResponse = await res.json();
+
+  if (!json.success || !json.data) {
+    throw new Error("API error");
+  }
+
+  const { account, stats } = json.data;
 
   return {
-    name: json?.data?.username ?? "Unknown",
-    handle: json?.data?.email ?? `user-${userId}`,
-    tier: json?.data?.tier ?? "Bronze",
-    email: json?.data?.email,
-    image: json?.data?.profile_pic ?? null,
-    avg_accuracy: json?.data?.stats?.avg_accuracy ?? null,
-    max_combo: json?.data?.stats?.max_combo ?? null,
-    play_count: json?.data?.stats?.play_count ?? null,
+    name: account.username ?? "Unknown",
+    handle: account.email ?? `user-${userId}`,
+    tier: "Bronze",
+    email: account.email,
+    image: account.profile_pic ?? null,
+
+    avg_accuracy: stats.avg_accuracy ?? null,
+    max_combo: stats.max_combo ?? null,
+    play_count: stats.play_count ?? null,
   };
 }


### PR DESCRIPTION
- /user/profile 응답 구조(account, stats) 기준으로 파싱 로직 수정
- 프로필 이미지 및 통계 필드 매핑 수정
- tier 값을 Bronze로 고정(임시)