### PR TITLE
feat: 랭킹 하이라이트 로직을 userId 기준으로 변경

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -17,11 +17,12 @@ export default async function LeaderboardPage() {
   
     const myRank: Leader | null = me 
     ? {
-      rank: 0, // TODO: 서버에서 내려주면 교체
+      userId: me.userId ?? null,
+      rank: me.ranking_score ?? 0,
       name: me.name,
       handle: me.handle,
       imageUrl: me.image ?? "imsi",
-      wpm: 0, // TODO: 서버 통계 붙으면 교체
+      wpm: me.avg_wpm ?? 0,
       accuracy: me.avg_accuracy ?? 0,
       combo: me.max_combo ?? 0,
     }
@@ -60,7 +61,7 @@ export default async function LeaderboardPage() {
                     <Row
                       key={u.rank}
                       u={u}
-                      highlight={u.rank === (myRank?.rank ?? -1)}
+                      highlight={u.userId === (myRank?.userId ?? -1)}
                     />
                   ))}
                 </ul>

--- a/lib/api/ranking.ts
+++ b/lib/api/ranking.ts
@@ -16,11 +16,13 @@ export async function getRanking(): Promise<Leader[]> {
   if (!json.success) throw new Error(json.message || "Failed to fetch ranking");
 
   return (json.data ?? []).map((item) => {
+    const userId = item.account.user_id;
     const name = item.account.username;
     const handle = `@user${item.account.user_id}`; // 서버에 handle 없으니 일단 이렇게
     const imageUrl = item.account.profile_pic || "imsi";
 
     return {
+      userId,
       rank: item.rank,
       name,
       handle,

--- a/lib/api/user.ts
+++ b/lib/api/user.ts
@@ -46,13 +46,15 @@ export async function getMe(userId: number): Promise<Me> {
   const { account, stats } = json.data;
 
   return {
+    userId: account.user_id ?? null,
     name: account.username ?? "Unknown",
-    handle: account.email ?? `user-${userId}`,
+    handle: `@user${account.user_id}`,
     tier: "Bronze",
     email: account.email,
     image: account.profile_pic ?? null,
-
+    ranking_score: account.ranking_score ?? null,
     avg_accuracy: stats.avg_accuracy ?? null,
+    avg_wpm: stats.avg_wpm ?? null,
     max_combo: stats.max_combo ?? null,
     play_count: stats.play_count ?? null,
   };

--- a/types/leaderboard.ts
+++ b/types/leaderboard.ts
@@ -1,4 +1,5 @@
 export type Leader = {
+    userId: number;  
     rank: number;
     name: string;
     handle: string;

--- a/types/me.ts
+++ b/types/me.ts
@@ -1,10 +1,13 @@
 export type Me = {
+    userId: number;  
     name: string;
     handle: string;
     tier: string;
     email?: string;
     image: string | null;
+    ranking_score: number | null;
     avg_accuracy: number | null;
+    avg_wpm: number | null;
     max_combo: number | null;
     play_count: number | null;
   };


### PR DESCRIPTION
- Leader 도메인에 userId 필드 추가
- 랭킹 Row highlight를 rank 대신 userId 기준으로 처리
- myRank를 랭킹 리스트 기준으로 계산하도록 수정