### PR TITLE
fix: TypingTopBar에서 WPM/CPM 라벨 위치 수정

### DIFF
--- a/components/molecules/ResultModal.tsx
+++ b/components/molecules/ResultModal.tsx
@@ -60,8 +60,8 @@ export function ResultModal({
 
         {/* stats */}
         <div className="grid grid-cols-3 divide-x divide-neutral-200 border-b border-neutral-200">
-          <StatCell label="CPM" value={result.cpm} />
           <StatCell label="WPM" value={result.wpm} />
+          <StatCell label="CPM" value={result.cpm} />
           <StatCell label="ACC" value={`${result.acc}%`} />
         </div>
         {/* text meta (UI only) */}


### PR DESCRIPTION
- TypingTopBar에서 WPM과 CPM 통계 라벨이 서로 뒤바뀌어 표시되던 ui 수정