### PR TITLE
feat: 관리자 계정일 때 Admin 페이지 노출 처리 및 레이아웃 위치 조정

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,10 @@
+export default function AdminPage(){
+    return (
+        <main className="min-h-screen bg-neutral-100">
+            <div className="mx-auto w-full max-w-6xl px-4 py-10 mt-14">
+                관리자용 페이지
+            </div>
+        </main>
+  
+    )
+}

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -33,14 +33,14 @@ export default async function LeaderboardPage() {
           {/* desktop layout */}
           <div
             className={[
-              "mt-6 grid gap-6",
+              "mt-14 grid gap-6",
               myRank ? "md:grid-cols-[320px_1fr]" : "md:grid-cols-1",
             ].join(" ")}
           >
             {/* left (desktop only) - 로그인 했을 때만 아예 렌더 */}
             {myRank && (
               <aside className="hidden md:block">
-                <div className="sticky top-[88px] mt-8">
+                <div className="sticky top-[88px]">
                   <MyRankSideCard me={myRank} />
                 </div>
               </aside>
@@ -48,9 +48,9 @@ export default async function LeaderboardPage() {
     
             {/* right */}
             <section className="min-w-0">
-              <div className="mt-6 border-b border-neutral-200">
+              <div className="border-b border-neutral-200">
                 <div className="flex items-center justify-between border-b border-neutral-200 px-5 py-4">
-                  <div className="text-sm font-semibold text-neutral-900">
+                  <div className="text-xl font-semibold text-neutral-900">
                     Rankings
                   </div>
                   <div className="text-xs text-neutral-500">Updated just now</div>

--- a/app/my/page.tsx
+++ b/app/my/page.tsx
@@ -142,7 +142,7 @@ export default async function MyPage() {
 
   return (
     <main className="min-h-screen bg-neutral-100">
-      <div className="mx-auto w-full max-w-6xl px-4 py-10">
+      <div className="mx-auto w-full max-w-6xl px-4 py-10 mt-14">
         {/* header */}
         {/* <div className="flex flex-col gap-2">
           <h1 className="text-2xl font-bold tracking-tight text-neutral-900">My Page</h1>

--- a/components/atoms/NavLink.tsx
+++ b/components/atoms/NavLink.tsx
@@ -17,7 +17,7 @@ export function NavLink({ href, children, external }: Props) {
     "relative text-xs font-medium text-neutral-700 hover:text-neutral-600 transition-colors";
 
   const content = (
-    <span className="inline-block w-[100px] text-left">
+    <span className="inline-block">
       {hovered ? (
         <DecryptedText
           text={children}

--- a/components/molecules/HeaderNav.tsx
+++ b/components/molecules/HeaderNav.tsx
@@ -1,8 +1,14 @@
 // components/molecules/HeaderNav.tsx
+"use client"
+import { useEffect } from "react";
 import { Logo } from "../atoms/Logo";
 import { NavLink } from "../atoms/NavLink";
+import { useSession } from "next-auth/react";
 
 export function HeaderNav() {
+  const {data: session} = useSession();
+  const isAdmin = Boolean((session?.user as any)?.is_admin);
+  
   return (
     <nav 
       className="flex w-full items-center justify-between gap-6"
@@ -10,7 +16,8 @@ export function HeaderNav() {
     >
       <Logo />
 
-      <div className="flex items-center gap-4 text-sm">
+      <div className="flex items-center gap-8 text-sm">
+        {isAdmin && <NavLink href="/admin">Admin</NavLink>}
         <NavLink href="/leaderboard">Leaderboard</NavLink>
         <NavLink href="/my">MyPage</NavLink>
       </div> 

--- a/components/molecules/mypage/MyProfileSection.tsx
+++ b/components/molecules/mypage/MyProfileSection.tsx
@@ -14,7 +14,7 @@ export function MyProfileSection({ me }: { me: Me }) {
 
   return (
     <>
-      <section className="mt-6 overflow-hidden border-neutral-200">
+      <section className="overflow-hidden border-neutral-200">
         {/* header */}
         <div className="p-5">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,12 +1,11 @@
-import NextAuth from "next-auth";
+// types/next-auth.d.ts
+import { DefaultSession } from "next-auth";
 
 declare module "next-auth" {
   interface Session {
-    user: {
-      user_id: number; // 또는 string (서버가 뭘 주는지에 맞춰)
-      name?: string | null;
-      email?: string | null;
-      image?: string | null;
+    user: DefaultSession["user"] & {
+      user_id: number;
+      is_admin: boolean;
     };
   }
 }


### PR DESCRIPTION
- 관리자 계정 여부를 세션에 반영해 Admin 페이지를 조건부로 노출
- 백엔드 응답 필드(indinfo)를 프론트 표준 필드(is_admin)로 매핑
- 고정 헤더 높이에 맞춰 전역 레이아웃 및 사이드 카드 위치 미세 조정