### PR TITLE
feat: 다음 곡 프리페치 로딩 토스트 추가

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -75,3 +75,11 @@ body {
     opacity: 0;
   }
 }
+
+/* ===============================
+   React Toastify Custom Styles
+   =============================== */
+.Toastify__spinner {
+  border-color: #fb4058 !important;
+  border-right-color: transparent !important;
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -3,6 +3,8 @@
 import { SessionProvider } from "next-auth/react";
 import {QueryClient, QueryClientProvider} from "@tanstack/react-query"
 import { useState } from "react";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
 
 export default function Providers({
   children,
@@ -15,6 +17,18 @@ export default function Providers({
     <SessionProvider>
       <QueryClientProvider client={queryClient}>
         {children}
+        <ToastContainer
+          position="bottom-right"
+          autoClose={false}
+          hideProgressBar
+          newestOnTop={false}
+          closeOnClick={false}
+          closeButton={false}
+          rtl={false}
+          pauseOnFocusLoss={false}
+          draggable={false}
+          theme="light"
+        />
       </QueryClientProvider>
     </SessionProvider>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next-auth": "^4.24.13",
         "react": "19.2.0",
         "react-dom": "19.2.0",
+        "react-toastify": "^11.0.5",
         "zustand": "^5.0.9"
       },
       "devDependencies": {
@@ -2625,6 +2626,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -5664,6 +5674,19 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next-auth": "^4.24.13",
     "react": "19.2.0",
     "react-dom": "19.2.0",
+    "react-toastify": "^11.0.5",
     "zustand": "^5.0.9"
   },
   "devDependencies": {


### PR DESCRIPTION
- 다음 곡 프리페치 진행 중 로딩 토스트 도입
- 토스트가 1.5초 노출되도록 구현
- react-toastify 로딩 스피너를 #fb4058로 커스터마이징