### PR TITLE
fix: 로그인 페이지 이탈 시 토스트가 남는 문제 수정

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,7 +2,16 @@
 
 import { signIn } from "next-auth/react";
 import { toast } from "react-toastify";
+import { useEffect } from "react";
+
 export default function LoginPageUI() {
+
+  useEffect(() => {
+    return () => {
+      toast.dismiss();
+    }
+  }, [])
+  
   return (
     <main className="min-h-screen bg-neutral-100 px-8 py-32">
       {/* 전체 레이아웃 */}


### PR DESCRIPTION
- 로그인 페이지 언마운트 시 toast.dismiss() 처리
- 다른 페이지로 이동해도 토스트가 유지되던 버그 해결