### PR TITLE
feat: 리더보드 테이블 헤더 추가 및 내 랭킹 하이라이트 개선

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -1,7 +1,7 @@
 // app/leaderboard/page.tsx
 import { getRanking } from "@/lib/api/ranking";
-import { Row } from "@/components/organisms/LeaderboardRow";
 import MyRankSideCardClient from "@/components/organisms/MyRankSideCardClient";
+import LeaderboardList from "@/components/organisms/LeaderboardList";
 
 export const revalidate = 600;
 
@@ -29,7 +29,7 @@ export default async function LeaderboardPage() {
           <section className="min-w-0">
             <div className="border-b border-neutral-200">
               <div className="flex items-center justify-between border-b border-neutral-200 px-5 py-4">
-                <div className="text-xl font-semibold text-neutral-900">
+                <div className="text-3xl font-semibold text-neutral-900">
                   Rankings
                 </div>
                 <div className="text-xs text-neutral-500">
@@ -39,11 +39,19 @@ export default async function LeaderboardPage() {
                 </div>
               </div>
 
-              <ul className="divide-y divide-neutral-200">
-                {ranking.map((u) => (
-                  <Row key={u.userId} u={u} highlight={false} />
-                ))}
-              </ul>
+              <div className="sticky top-0 z-10 flex items-center gap-4 border-b border-neutral-200 bg-neutral-100 px-5 py-3 text-xs font-semibold text-neutral-500">
+                <div className="w-10 text-center">#</div>
+                <div className="h-10 w-10" />
+                <div className="min-w-0 flex-1">Name</div>
+                <div className="hidden sm:flex items-center gap-2">
+                  <div className="w-[72px] text-center">WPM</div>
+                  <div className="w-[72px] text-center">ACC</div>
+                  {/* TODO: 콤보 구현 후 주석 해제 */}
+                  {/* <div className="w-[72px] text-center">Combo</div> */}
+                </div>
+              </div>
+
+              <LeaderboardList ranking={ranking} />
             </div>
           </section>
         </div>

--- a/components/organisms/LeaderboardList.tsx
+++ b/components/organisms/LeaderboardList.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { Leader } from "@/types/leaderboard";
+import { Row } from "./LeaderboardRow";
+
+export default function LeaderboardList({ ranking }: { ranking: Leader[] }) {
+  const { data: session } = useSession();
+  const userId = (session?.user as any)?.user_id;
+
+  return (
+    <ul className="divide-y divide-neutral-200">
+      {ranking.map((u) => (
+        <Row key={u.userId} u={u} highlight={u.userId === userId} />
+      ))}
+    </ul>
+  );
+}

--- a/components/organisms/LeaderboardRow.tsx
+++ b/components/organisms/LeaderboardRow.tsx
@@ -3,12 +3,13 @@ export function Row({ u, highlight }: { u: Leader; highlight?: boolean }) {
     return (
       <li
         className={[
-          "flex items-center gap-4 px-5 py-4",
-          highlight
-            ? "ring-3 ring-[#fb4058]/40"
-            : "hover:bg-neutral-50",
+          "relative flex items-center gap-4 px-5 py-4",
+          highlight ? "bg-neutral-50" : "",
         ].join(" ")}
       >
+        {highlight && (
+          <div className="absolute left-0 top-0 h-full w-[3px] bg-[#fb4058]/50" />
+        )}
         <div
           className={[
             "w-10 text-center text-sm font-semibold tabular-nums",
@@ -32,8 +33,13 @@ export function Row({ u, highlight }: { u: Leader; highlight?: boolean }) {
         </div>
   
         <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-semibold text-neutral-900">
+          <div className="flex items-center gap-1.5 truncate text-sm font-semibold text-neutral-900">
             {u.name}
+            {highlight && (
+              <span className="rounded bg-[#fb4058]/70 px-1.5 py-0.5 text-[10px] font-bold leading-none text-white">
+                ME
+              </span>
+            )}
           </div>
           <div className="truncate text-xs text-neutral-500">
             {u.handle}
@@ -41,22 +47,17 @@ export function Row({ u, highlight }: { u: Leader; highlight?: boolean }) {
         </div>
   
         <div className="hidden sm:flex items-center gap-2">
-          <div className="rounded-xl border border-neutral-200 bg-white px-3 py-2 text-xs font-semibold tabular-nums text-neutral-800">
-            {u.wpm} WPM
+          <div className="w-[72px] rounded-xl border border-neutral-200 bg-white px-3 py-2 text-center text-xs font-semibold tabular-nums text-neutral-800">
+            {u.wpm}
           </div>
-          <div className="rounded-xl border border-neutral-200 bg-white px-3 py-2 text-xs font-semibold tabular-nums text-neutral-800">
+          <div className="w-[72px] rounded-xl border border-neutral-200 bg-white px-3 py-2 text-center text-xs font-semibold tabular-nums text-neutral-800">
             {u.accuracy.toFixed(1)}%
           </div>
-          <div className="rounded-xl border border-neutral-200 bg-white px-3 py-2 text-xs font-semibold tabular-nums text-neutral-800">
+          {/* TODO: 콤보 구현 후 주석 해제 */}
+          {/* <div className="w-[72px] rounded-xl border border-neutral-200 bg-white px-3 py-2 text-center text-xs font-semibold tabular-nums text-neutral-800">
             x{u.combo}
-          </div>
+          </div> */}
         </div>
-  
-        <button
-          className="ml-2 rounded-xl border border-neutral-200 bg-white px-3 py-2 text-xs font-semibold text-neutral-700 hover:bg-neutral-50"
-        >
-          보기
-        </button>
       </li>
     );
 }


### PR DESCRIPTION
- sticky 테이블 헤더(#, Name, WPM, ACC) 추가
- 내 행에 왼쪽 컬러 바 + ME 뱃지로 하이라이트 표시
- 하이라이트 판별을 클라이언트 컴포넌트(LeaderboardList)로 분리
- 콤보/보기 버튼 임시 제거