### PR TITLE
fix: 리더보드 레이아웃 및 하이라이트 개선

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -18,17 +18,12 @@ export default async function LeaderboardPage() {
   return (
     <main className="min-h-screen bg-neutral-100">
       <div className="mx-auto w-full max-w-6xl px-4 py-10">
-        <div className="mt-14 grid gap-6 md:grid-cols-[320px_1fr]">
-          {/* 왼쪽: 클라에서만 결정 */}
-          <aside className="hidden md:block">
-            <div className="sticky top-[88px]">
-              <MyRankSideCardClient ranking={ranking} />
-            </div>
-          </aside>
+        <div className="mt-14 flex justify-center gap-6">
+          <MyRankSideCardClient ranking={ranking} />
 
-          <section className="min-w-0">
+          <section className="min-w-0 max-w-4xl flex-1">
             <div className="border-b border-neutral-200">
-              <div className="flex items-center justify-between border-b border-neutral-200 px-5 py-4">
+              <div className="flex items-center justify-between px-5 py-4">
                 <div className="text-3xl font-semibold text-neutral-900">
                   Rankings
                 </div>
@@ -38,6 +33,8 @@ export default async function LeaderboardPage() {
                   <span>최근 갱신: {updatedAt}</span>
                 </div>
               </div>
+
+              <div className="mt-1" />
 
               <div className="sticky top-0 z-10 flex items-center gap-4 border-b border-neutral-200 bg-neutral-100 px-5 py-3 text-xs font-semibold text-neutral-500">
                 <div className="w-10 text-center">#</div>

--- a/components/organisms/LeaderboardRow.tsx
+++ b/components/organisms/LeaderboardRow.tsx
@@ -47,10 +47,10 @@ export function Row({ u, highlight }: { u: Leader; highlight?: boolean }) {
         </div>
   
         <div className="hidden sm:flex items-center gap-2">
-          <div className="w-[72px] rounded-xl border border-neutral-200 bg-white px-3 py-2 text-center text-xs font-semibold tabular-nums text-neutral-800">
+          <div className="w-[72px] px-3 py-2 text-center text-xs font-semibold tabular-nums text-neutral-800">
             {u.wpm}
           </div>
-          <div className="w-[72px] rounded-xl border border-neutral-200 bg-white px-3 py-2 text-center text-xs font-semibold tabular-nums text-neutral-800">
+          <div className="w-[72px] px-3 py-2 text-center text-xs font-semibold tabular-nums text-neutral-800">
             {u.accuracy.toFixed(1)}%
           </div>
           {/* TODO: 콤보 구현 후 주석 해제 */}

--- a/components/organisms/MyRankSideCardClient.tsx
+++ b/components/organisms/MyRankSideCardClient.tsx
@@ -14,5 +14,11 @@ export default function MyRankSideCardClient({ ranking }: { ranking: Leader[] })
   const me = ranking.find((u) => u.userId === userId);
   if (!me) return null;
 
-  return <MyRankSideCard me={me} />;
+  return (
+    <aside className="hidden md:block w-[320px] shrink-0">
+      <div className="sticky top-[88px]">
+        <MyRankSideCard me={me} />
+      </div>
+    </aside>
+  );
 }


### PR DESCRIPTION
- 비로그인 시 랭킹 리스트 중앙 정렬 (grid → flex 변경)
- aside를 MyRankSideCardClient 내부로 이동하여 비로그인 시 DOM에서 제거
- 내 행 하이라이트를 왼쪽 컬러 바 + ME 뱃지로 변경
- Rankings 타이틀과 리스트 사이 간격 조정 및 불필요한 border 제거