### PR TITLE
feature: 곡 프리페치 최대 횟수 12회로 증가

### DIFF
--- a/components/organisms/SongTypeBoard.tsx
+++ b/components/organisms/SongTypeBoard.tsx
@@ -55,7 +55,7 @@ export function SongTypeBoard({ songs }: Props) {
     status,
     fetchMoreSongs,
     prefetchFromEnd: 2, // 끝에서 2개 남으면
-    maxPrefetch: 2,
+    maxPrefetch: 12,
   });
 
   const [input, setInput] = useState("");


### PR DESCRIPTION
## Summary                                                             
  - 곡 프리페치 최대 횟수를 2회 → 12회로 증가                            
  - DB에 등록된 곡 수(60+)를 충분히 커버할 수 있도록 변경                

 ## Note                                                                
  - 랜덤 API 특성상 중복 곡이 반환될 수 있어, 기존 중복 제거 로직은 유지
  - 12회 × 10곡 = 최대 120곡까지 프리페치 가능     