### PR TITLE
feat: 타이핑 결과 모달에 WPM/ACC 시계열 차트 추가

### DIFF
--- a/components/molecules/ResultModal.tsx
+++ b/components/molecules/ResultModal.tsx
@@ -3,7 +3,9 @@
 import { IconButton } from "../atoms/IconButton";
 import { useSession } from "next-auth/react";
 import { ProfileAvatar } from "@/components/atoms/ProfileAvatar";
-type Result = { wpm: number; cpm: number; acc: number };
+import { TypingResultChart } from "./TypingResultChart";
+import type { MetricSnapshot } from "@/hooks/useLiveTypingMetrics";
+type Result = { wpm: number; cpm: number; acc: number; snapshots: MetricSnapshot[] };
 type SongMeta = {
   songId: number;
   imageUrl: string;
@@ -38,7 +40,7 @@ export function ResultModal({
       onMouseDown={onClose}
     >
       <div
-        className="relative w-full max-w-sm overflow-hidden bg-white shadow-2xl"
+        className="relative w-full max-w-lg overflow-hidden bg-white shadow-2xl"
         onMouseDown={(e) => e.stopPropagation()}
       >
         {/* close */}
@@ -53,7 +55,7 @@ export function ResultModal({
         {/* header */}
         <div className="border-b border-neutral-200 px-6 pb-5 pt-10 text-center">
           <div className="text-xl font-extrabold tracking-tight text-neutral-900">
-            LyricType
+            TypeSomething
           </div>
           
         </div>
@@ -64,6 +66,13 @@ export function ResultModal({
           <StatCell label="CPM" value={result.cpm} />
           <StatCell label="ACC" value={`${result.acc}%`} />
         </div>
+        {/* chart */}
+        <div className="border-b border-neutral-200 px-4 py-3">
+          <div className="mx-auto max-w-md">
+            <TypingResultChart snapshots={result.snapshots} />
+          </div>
+        </div>
+
         {/* text meta (UI only) */}
         <div className="border-b border-neutral-200 px-6 py-5">
           <div className="flex gap-4">
@@ -72,7 +81,7 @@ export function ResultModal({
                   src={song.imageUrl}
                   alt=""
                   className="h-full w-full object-cover"
-                />           
+                />
             </div>
             <div>
               <div className="text-base font-semibold text-neutral-900">
@@ -84,7 +93,7 @@ export function ResultModal({
               </div>
             </div>
           </div>
-        
+
           <div className="mt-3 inline-flex items-center gap-1 rounded border border-neutral-300 px-2 py-0.5 text-xs font-medium text-neutral-600">
             📜 KPOP
           </div>

--- a/components/molecules/TypingResultChart.tsx
+++ b/components/molecules/TypingResultChart.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useMemo } from "react";
+import ReactEChartsCore from "echarts-for-react/lib/core";
+import * as echarts from "echarts/core";
+import { LineChart } from "echarts/charts";
+import {
+  GridComponent,
+  TooltipComponent,
+  LegendComponent,
+} from "echarts/components";
+import { CanvasRenderer } from "echarts/renderers";
+import type { MetricSnapshot } from "@/hooks/useLiveTypingMetrics";
+
+echarts.use([LineChart, GridComponent, TooltipComponent, LegendComponent, CanvasRenderer]);
+
+type Props = {
+  snapshots: MetricSnapshot[];
+};
+
+export function TypingResultChart({ snapshots }: Props) {
+  const option = useMemo(() => {
+    const seconds = snapshots.map((s) => `${s.second}s`);
+    const wpmData = snapshots.map((s) => s.wpm);
+    const accData = snapshots.map((s) => s.acc);
+
+    return {
+      tooltip: {
+        trigger: "axis" as const,
+        backgroundColor: "rgba(255,255,255,0.95)",
+        borderColor: "#e5e5e5",
+        borderWidth: 1,
+        textStyle: { color: "#404040", fontSize: 12 },
+        formatter(params: Array<{ seriesName: string; value: number; marker: string }>) {
+          const lines = params.map(
+            (p) => `${p.marker} ${p.seriesName}: <b>${p.value}${p.seriesName === "ACC" ? "%" : ""}</b>`
+          );
+          return lines.join("<br/>");
+        },
+      },
+      legend: {
+        data: ["WPM", "ACC"],
+        bottom: 0,
+        textStyle: { color: "#737373", fontSize: 11 },
+        itemWidth: 16,
+        itemHeight: 8,
+      },
+      grid: {
+        left: 40,
+        right: 40,
+        top: 16,
+        bottom: 32,
+        containLabel: false,
+      },
+      xAxis: {
+        type: "category" as const,
+        data: seconds,
+        axisLine: { lineStyle: { color: "#d4d4d4" } },
+        axisLabel: { color: "#a3a3a3", fontSize: 10 },
+        axisTick: { show: false },
+      },
+      yAxis: [
+        {
+          type: "value" as const,
+          name: "WPM",
+          nameTextStyle: { color: "#a3a3a3", fontSize: 10 },
+          axisLine: { show: false },
+          axisTick: { show: false },
+          axisLabel: { color: "#a3a3a3", fontSize: 10 },
+          splitLine: { lineStyle: { color: "#f0f0f0" } },
+        },
+        {
+          type: "value" as const,
+          name: "ACC",
+          min: 0,
+          max: 100,
+          nameTextStyle: { color: "#a3a3a3", fontSize: 10 },
+          axisLine: { show: false },
+          axisTick: { show: false },
+          axisLabel: { color: "#a3a3a3", fontSize: 10, formatter: "{value}%" },
+          splitLine: { show: false },
+        },
+      ],
+      series: [
+        {
+          name: "WPM",
+          type: "line" as const,
+          smooth: true,
+          symbol: "circle",
+          symbolSize: 4,
+          lineStyle: { width: 1.5, color: "#fb4058" },
+          itemStyle: { color: "#fb4058" },
+          areaStyle: {
+            color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
+              { offset: 0, color: "rgba(251,64,88,0.15)" },
+              { offset: 1, color: "rgba(251,64,88,0)" },
+            ]),
+          },
+          data: wpmData,
+          yAxisIndex: 0,
+        },
+        {
+          name: "ACC",
+          type: "line" as const,
+          smooth: true,
+          symbol: "circle",
+          symbolSize: 4,
+          lineStyle: { width: 1.5, color: "#64748b", type: "dashed" as const },
+          itemStyle: { color: "#64748b" },
+          data: accData,
+          yAxisIndex: 1,
+        },
+      ],
+    };
+  }, [snapshots]);
+
+  if (snapshots.length < 2) return null;
+
+  return (
+    <div className="w-full">
+      <ReactEChartsCore
+        echarts={echarts}
+        option={option}
+        style={{ height: 140, width: "100%" }}
+        notMerge
+        lazyUpdate
+      />
+    </div>
+  );
+}

--- a/components/organisms/SongTypeBoard.tsx
+++ b/components/organisms/SongTypeBoard.tsx
@@ -11,6 +11,7 @@ import { SettingsSidebar } from "./SettingsSidebar";
 import { LyricsListSidebar } from "./LyricsListSidebar";
 import { Song } from "@/types/song";
 import { parseTypingLine } from "@/utils/parseTypingLine";
+import type { MetricSnapshot } from "@/hooks/useLiveTypingMetrics";
 import { useSession } from "next-auth/react";
 import { usePostTextResult } from "@/query/usePostTextResult";
 import { usePostFavorite } from "@/query/usePostFavorite";
@@ -21,7 +22,7 @@ type Props = {
   songs: Song[];
 }
 
-type Result = { wpm: number; cpm: number; acc: number };
+type Result = { wpm: number; cpm: number; acc: number; snapshots: MetricSnapshot[] };
 
 export function SongTypeBoard({ songs }: Props) {
   const { data: session, status } = useSession(); // authenticated / unauthenticated / loading
@@ -79,7 +80,7 @@ export function SongTypeBoard({ songs }: Props) {
   const progress = Math.min(Math.round((input.length / text.length) * 100), 100);
   const cursorIndex = Math.min(input.length, text.length);
   
-  const { metrics, resetMetrics } = useLiveTypingMetrics(text, input, isComposing);
+  const { metrics, snapshots, resetMetrics } = useLiveTypingMetrics(text, input, isComposing);
   
   const wpm = metrics.wpm;
   const cpm = metrics.cpm;
@@ -243,7 +244,7 @@ export function SongTypeBoard({ songs }: Props) {
   
       e.preventDefault();
 
-      const final = { wpm: metrics.wpm, cpm: metrics.cpm, acc: metrics.acc};
+      const final = { wpm: metrics.wpm, cpm: metrics.cpm, acc: metrics.acc, snapshots: [...snapshots] };
 
       // 1) 로그인 여부 상관없이 모달은 띄움
       setResult(final);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.90.16",
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
         "motion": "^12.23.26",
         "next": "16.0.7",
         "next-auth": "^4.24.13",
@@ -4982,6 +4984,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/echarts": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
+      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.0.0"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.6.tgz",
+      "integrity": "sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.265",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.265.tgz",
@@ -5763,7 +5795,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -10262,6 +10293,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
+      "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==",
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -11785,6 +11822,21 @@
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
+    },
+    "node_modules/zrender": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
+      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/zustand": {
       "version": "5.0.9",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.16",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "motion": "^12.23.26",
     "next": "16.0.7",
     "next-auth": "^4.24.13",


### PR DESCRIPTION
 Summary                                                                                                                                                         
                                                                                                                                                                  
  - 타이핑 세션 종료 후 ResultModal에 ECharts 기반 WPM/ACC 시계열 차트 추가                                                                                       
  - 1초 간격 메트릭 스냅샷 수집 로직 구현 (useLiveTypingMetrics)                                                                                                  
  - Canvas 렌더링 + tree-shake import로 번들 최적화                                                                                                               
                                                                                                                                                                  
  Changes                                                                                                                                                         

  - echarts, echarts-for-react 패키지 추가
  - useLiveTypingMetrics: 1초마다 WPM/ACC 기록, 초반 튐 방지용 상한(120) 적용                                                                                     
  - TypingResultChart.tsx: WPM(좌축) + ACC(우축) 차트 컴포넌트                                                                                                    
  - SongTypeBoard.tsx: 스냅샷 데이터를 결과 모달로 전달   
  - ResultModal.tsx: 모달 확장 + 차트 삽입