### PR TITLE
fix: Jest가 e2e 테스트 파일을 실행하지 않도록 제외 처리

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,6 +6,7 @@ const createJestConfig = nextJest({ dir: "./" });
 const config: Config = {
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  testPathIgnorePatterns: ["/node_modules/", "/e2e/"],
 };
 
 export default createJestConfig(config);


### PR DESCRIPTION
 - jest.config.ts에 testPathIgnorePatterns에 /e2e/ 추가                                                                                                                                                                
 - @playwright/test import가 Jest 환경에서 충돌하는 문제 해결    