### PR TITLE
feat: 전체 페이지 푸터 추가 및 메인페이지에서 고정 처리

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AppHeader } from "@/components/organisms/AppHeader";
-import { AppFooter } from "@/components/organisms/AppFooter";
+import { FooterController } from "@/components/organisms/FooterController";
 import { orbit, inter, orbitron, grandiflora } from "./font";
 import Providers from "./providers";
 
@@ -70,7 +70,7 @@ export default function RootLayout({
           <main className="min-h-screen">
             {children}
           </main>
-          {/* <AppFooter /> */}
+          <FooterController />
        </Providers>
       </body>
     </html>

--- a/components/organisms/AppFooter.tsx
+++ b/components/organisms/AppFooter.tsx
@@ -1,21 +1,29 @@
-// components/organisms/AppFooter.tsx
 import Link from "next/link";
 
-export function AppFooter(){
-    return(
-        <footer className="border-t border-neutral-800 bg-neutral-950 text-neutral-500">
-            <div className="mx-auto flex h-12 max-w-5xl items-center justify-between px-4 text-xs">
-                <span>© 2025 Typing Something</span>
-                <div>
-                    <Link 
-                    href="https://github.com/..."
-                    className="hover:text-neutral-200 transition-colors underline-offset-4 hover:underline"                    
-                    >
-                        GitHub
-                    </Link>
-                </div>
-            </div>
+type AppFooterProps = {
+  fixed?: boolean;
+};
 
-        </footer>
-    )
+export function AppFooter({ fixed = false }: AppFooterProps) {
+  return (
+    <footer
+      className={`${
+        fixed ? "fixed inset-x-0 bottom-0 z-50" : ""
+      } bg-neutral-100 text-neutral-500`}
+    >
+      <div className="mx-auto flex h-12 max-w-5xl items-center justify-between px-4 text-xs">
+        <span>© 2026 Typing Something</span>
+        <div>
+          <Link
+            href="https://github.com/Typing-something"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline-offset-4 transition-colors hover:text-neutral-900 hover:underline"
+          >
+            GitHub
+          </Link>
+        </div>
+      </div>
+    </footer>
+  );
 }

--- a/components/organisms/FooterController.tsx
+++ b/components/organisms/FooterController.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { AppFooter } from "./AppFooter";
+
+export function FooterController() {
+  const pathname = usePathname();
+  return <AppFooter fixed={pathname === "/"} />;
+}


### PR DESCRIPTION
 - AppFooter에 fixed prop 추가, 메인페이지(/")에서는 하단 고정, 나머지 페이지는 일반 flow
 - FooterController(client) 생성 — usePathname으로 경로별 렌더 분기
 - layout.tsx에 FooterController 적용해 전체 페이지에 푸터 노출
 - GitHub 링크 target="_blank" 처리로 새 탭에서 열리도록 변경